### PR TITLE
Fix goal handle pointer for Humble

### DIFF
--- a/include/action_bridge/action_bridge_1_2.hpp
+++ b/include/action_bridge/action_bridge_1_2.hpp
@@ -152,7 +152,7 @@ private:
       auto send_goal_ops = ROS2SendGoalOptions();
       send_goal_ops.goal_response_callback =
           [this](auto gh2_future) mutable {
-            auto goal_handle = gh2_future.get();
+            auto goal_handle = gh2_future;
             if (!goal_handle)
             {
               gh1_.setRejected(); // goal was not accepted by remote server
@@ -163,9 +163,7 @@ private:
 
             {
               std::lock_guard<std::mutex> lock(mutex_);
-              //gh2_ = goal_handle;
-              ROS2GoalHandle tmp(goal_handle);
-              gh2_ = tmp;
+              gh2_ = goal_handle;
 
               if (canceled_)
               { // cancel was called in between


### PR DESCRIPTION
Copying the raw pointer actually causes a segfault when the object is destroyed. Instead, the raw pointer can be avoided altogether but not calling the `.get()` method.